### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.csv
+*.html
+*.json
+*.egg-info


### PR DESCRIPTION
Avoid commiting unnecessary files and folders, like output files in the reports
directory and all pycache and *.egg-info directories.